### PR TITLE
Add simple chat interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,31 @@
-# React + Vite
+# ChatGPT UI
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Simple chat UI built with React and Vite. It allows you to converse with OpenAI models.
 
-Currently, two official plugins are available:
+## Setup
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+Install dependencies:
+
+```bash
+npm install
+```
+
+Create a `.env` file and define your OpenAI API key:
+
+```bash
+VITE_OPENAI_API_KEY=YOUR_KEY_HERE
+```
+
+## Development
+
+Start the development server:
+
+```bash
+npm run dev
+```
+
+## Build
+
+```bash
+npm run build
+```

--- a/src/components/Chat.css
+++ b/src/components/Chat.css
@@ -1,0 +1,47 @@
+.chat-container {
+  display: flex;
+  flex-direction: column;
+  height: 80vh;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+}
+
+.message {
+  padding: 0.5rem 1rem;
+  margin-bottom: 0.75rem;
+  border-radius: 4px;
+  max-width: 80%;
+  word-wrap: break-word;
+}
+
+.message.user {
+  align-self: flex-end;
+  background-color: #cef;
+}
+
+.message.ai {
+  align-self: flex-start;
+  background-color: #eee;
+}
+
+.chat-input {
+  display: flex;
+  padding: 0.5rem;
+  gap: 0.5rem;
+  border-top: 1px solid #ccc;
+}
+
+.chat-input textarea {
+  flex: 1;
+  resize: vertical;
+}
+
+.chat-input select {
+  margin-right: 0.5rem;
+}

--- a/src/components/Chat.jsx
+++ b/src/components/Chat.jsx
@@ -1,22 +1,86 @@
-// Functional React component for the chat window
+import { useState } from 'react'
+import './Chat.css'
+
+const MODELS = ['gpt-3.5-turbo', 'gpt-4o', 'gpt-4']
 
 const Chat = () => {
-  // Component should have a window showing the chat, a text input field in the bottom, and a button to send the message
+  const [messages, setMessages] = useState([])
+  const [input, setInput] = useState('')
+  const [model, setModel] = useState(MODELS[0])
+  const [loading, setLoading] = useState(false)
+
+  const sendMessage = async () => {
+    if (!input.trim()) return
+    const newMessages = [...messages, { role: 'user', content: input }]
+    setMessages(newMessages)
+    setInput('')
+    setLoading(true)
+
+    try {
+      const response = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${import.meta.env.VITE_OPENAI_API_KEY}`,
+        },
+        body: JSON.stringify({
+          model,
+          messages: newMessages,
+        }),
+      })
+      const data = await response.json()
+      const aiMessage = data.choices?.[0]?.message?.content
+      if (aiMessage) {
+        setMessages([...newMessages, { role: 'assistant', content: aiMessage }])
+      }
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      sendMessage()
+    }
+  }
 
   return (
-    <div>
-      <div>
-        <div>
-          <div>
-            <p>Message 1</p>
-            <p>Message 2</p>
-            <p>Message 3</p>
+    <div className="chat-container">
+      <div className="chat-messages">
+        {messages.map((msg, idx) => (
+          <div
+            key={idx}
+            className={msg.role === 'user' ? 'message user' : 'message ai'}
+          >
+            {msg.content}
           </div>
-        </div>
-        <div>
-          <input type="text" />
-          <button>Send</button>
-        </div>
+        ))}
+        {loading && <div className="message ai">...</div>}
+      </div>
+      <div className="chat-input">
+        <select
+          value={model}
+          onChange={(e) => setModel(e.target.value)}
+          disabled={loading}
+        >
+          {MODELS.map((m) => (
+            <option key={m} value={m}>
+              {m}
+            </option>
+          ))}
+        </select>
+        <textarea
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Type a message"
+        />
+        <button onClick={sendMessage} disabled={loading || !input.trim()}>
+          Send
+        </button>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- implement basic ChatGPT style UI with React
- add styles for the chat view
- document setup for OpenAI API key

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848e07e7674832ba8b6dbf15871020d